### PR TITLE
Fixes some small typos in multiple chapters

### DIFF
--- a/arch.rst
+++ b/arch.rst
@@ -378,7 +378,7 @@ The third group includes the one component that runs in the User Plane
 
 -  UPF (User Plane Function): Forwards traffic between RAN and the
    Internet, corresponding to the S/PGW combination in EPC. In addition
-   to packet forwarding, it responsible for policy enforcement, lawful
+   to packet forwarding, it is responsible for policy enforcement, lawful
    intercept, traffic usage reporting, and QoS policing.
 
 Of these, the first and third groups are best viewed as a

--- a/intro.rst
+++ b/intro.rst
@@ -215,7 +215,7 @@ we use CORD as our exemplar. For now, the important thing to understand
 is that 5G is being implemented as software running on commodity
 hardware, rather than embedded in the special-purpose proprietary
 hardware used in past generations. This has a significant impact on how
-we think about 5G (and how we describes 5G), which will increasingly
+we think about 5G (and how we describe 5G), which will increasingly
 become yet another software-based component in the cloud, as opposed to
 an isolated and specialized technology attached to the periphery of the
 cloud.

--- a/primer.rst
+++ b/primer.rst
@@ -295,6 +295,6 @@ depth in a later chapter.
     :width: 600px
     :align: center
 
-    Figure 2.5: Scheduler allocates Resource Elements to user data
+    Figure 2.5: Scheduler allocates Resource Blocks to user data
     streams based on CQI feedback from receivers and the QCI
     parameters associated with each class of service.

--- a/ran.rst
+++ b/ran.rst
@@ -144,7 +144,7 @@ API for exerting software-based control over the pipeline that
 implements the RAN user plane. To be more specific, the left
 sub-component simply forwards control packets between the Mobile Core
 and the PDCP, providing a path over which the Mobile Core can
-communication with the UE for control purposes, whereas the right
+communicate with the UE for control purposes, whereas the right
 sub-component implements the core of the RCC’s control functionality.
 
 .. _fig-rrc-split:


### PR DESCRIPTION
I assume the caption of Figure 2.5 meant to say _Resource Blocks_ instead of _Elements_.

Great overview in general, BTW!