### PR TITLE
Fixed Typos

### DIFF
--- a/arch.rst
+++ b/arch.rst
@@ -475,7 +475,7 @@ established between the UE and Core-UP, each with a potentially
 different QCI value. This might be done on an
 application-by-application basis, for example, under the control of
 the Mobile Core doing *Deep Packet Inspection* (DPI) on the traffic,
-looking for flows that that require special treatment.
+looking for flows that require special treatment.
 
 .. _fig-per-hop:
 .. figure:: figures/Slide35.png 

--- a/ran.rst
+++ b/ran.rst
@@ -255,7 +255,7 @@ available input data centrally, make a globally optimal decision, and
 then push the respective control parametes back to the base stations
 for execution. Realizing this value in the RAN is still a
 work-in-progress, but evidence using the same approach to optimize
-wide-are networks is compelling.
+wide-area networks is compelling.
   
 .. _reading_b4:
 .. admonition:: Further Reading

--- a/ran.rst
+++ b/ran.rst
@@ -159,7 +159,7 @@ packets between the Mobile Core and the PDCP, providing a path over
 which the Mobile Core can communicate with the UE for control
 purposes, whereas the right sub-component implements the core of the
 RCC’s control functionality. This component is commonly referred to as
-as the *RAN Intelligent Controller (RIC)* in O-RAN architecture
+the *RAN Intelligent Controller (RIC)* in O-RAN architecture
 documents, so we adopt this terminology.  The "Near-Real Time"
 qualifier indicates the RIC is part of 10-100ms control loop implemented
 in the CU, as opposed to the ~1ms control loop required by the MAC


### PR DESCRIPTION
Fixed a minor typo in Chapter 4: RAN Internals (ran.rst)